### PR TITLE
Move req to handler and get resp from it.

### DIFF
--- a/src/h2tp/handler.rs
+++ b/src/h2tp/handler.rs
@@ -1,33 +1,31 @@
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::{Arc};
-use tokio::sync::RwLock;
 use crate::h2tp::error::Error;
 use crate::h2tp::request::Request;
 use crate::h2tp::response::Response;
 
-type BoxedFuture = Pin<Box<dyn Future<Output=Result<(), Error>> + Send>>;
-type FuncType<'a> = fn(req: &'a mut Request, resp: &'a mut Response) -> BoxedFuture;
+type BoxedFuture = Pin<Box<dyn Future<Output=Result<Response, Error>> + Send>>;
+type FuncType = fn(req: Request) -> BoxedFuture;
 
-pub trait Handler<'a> {
-	fn handle(&self, req: &'a mut Request, resp: &'a mut Response) -> BoxedFuture;
+pub trait Handler {
+	fn handle(&self, req: Request) -> BoxedFuture;
 }
 
-pub struct FuncHandler<'a> {
-	f: FuncType<'a>,
+pub struct FuncHandler {
+	f: FuncType,
 }
 
-impl<'a> FuncHandler<'a> {
+impl FuncHandler {
 	#[inline]
 	pub fn new(f: FuncType) -> Self {
 		return Self { f };
 	}
 }
 
-impl<'a> Handler<'a> for FuncHandler<'a> {
+impl Handler for FuncHandler {
 	#[inline]
-	fn handle(&self, req: &'a mut Request, resp: &'a mut Response) -> BoxedFuture {
-		(self.f)(req, resp)
+	fn handle(&self, req: Request) -> BoxedFuture {
+		(self.f)(req)
 	}
 }
 

--- a/src/h2tp/mod.rs
+++ b/src/h2tp/mod.rs
@@ -30,7 +30,7 @@ pub fn server() -> server::Server {
 	return server::Server::new();
 }
 
-pub type FuncHandler<'a> = handler::FuncHandler<'a>;
+pub use handler::FuncHandler;
 
 #[macro_export]
 macro_rules! func {


### PR DESCRIPTION
按照你的描述，我对于 handler 的理解是：接受一个 Request 对象，返回一个 Response 对象。那么直接创建了 Request 之后移动给 handler，并要求 handler 创建 Response 并返回即可。

这样做相比于提前创建 Request 和 Response，也许会增加内存分配次数，但是不会增加占用。在分配内存并不是性能瓶颈的时候是可以接受的。

另外这样做可以扔掉许多显式生存期。

一些批评：
* 过度优化，不知道是不是 C++ 的坏毛病，声明一个全局的对象然后每次都修改它来避免内存分配（实际上无法完全避免）。
* `Arc<Box<>>` 智能指针要么 `Arc` 要么 `Box` ，不要套娃。